### PR TITLE
Algoritmo de Validacion con Personas Morales

### DIFF
--- a/src/RfcFacil/VerificationDigitCalculator.cs
+++ b/src/RfcFacil/VerificationDigitCalculator.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace RfcFacil
 {
@@ -79,11 +78,10 @@ namespace RfcFacil
             {
                 return "0";
             }
-            if (reminder > 0)
+            else
             {
-                return MapValue(11 - reminder);
+                return (11 - reminder).ToString("X");
             }
-            return null;
         }
 
         private int MapDigit(char c)
@@ -93,12 +91,6 @@ namespace RfcFacil
             bool hasOutput = Mapping.TryGetValue(c.ToString(), out outValue);
             
             return hasOutput ? outValue : 0;
-        }
-        
-        private string MapValue(int i)
-        {
-            var key = Mapping.FirstOrDefault(x => x.Value == i).Key;
-            return key;
         }
     }
 }

--- a/src/RfcFacil/VerificationDigitCalculator.cs
+++ b/src/RfcFacil/VerificationDigitCalculator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace RfcFacil
 {


### PR DESCRIPTION
Para personas morales solo es necesario insertar un espacio en blanco como primer caracter.
Esta prueba fue realizada contra la LCO (Lista de Contribuyentes y Obligaciones del SAT) de Enero 2014 con casi 1 millon de registros, teniendo los siguientes resultados:
Mi resultado fue un margen de error de 0.005%
Con en el codigo de la version original obtuve 0.2% de error.
